### PR TITLE
"Don't ask me again" functionality

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,8 @@
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.0",
     "vaadin-license-checker": "vaadin/license-checker#^2.1.0",
     "vaadin-dialog": "vaadin/vaadin-dialog#^2.1.0",
-    "vaadin-button": "vaadin/vaadin-button#^2.1.0"
+    "vaadin-button": "vaadin/vaadin-button#^2.1.0",
+    "vaadin-checkbox": "vaadin/vaadin-checkbox#^2.2.6"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",

--- a/build/default/src/vaadin-confirm-dialog.html
+++ b/build/default/src/vaadin-confirm-dialog.html
@@ -1,0 +1,377 @@
+<!--
+@license
+Copyright (c) 2018 Vaadin Ltd.
+This program is available under Commercial Vaadin Add-On License 3.0 (CVALv3).
+
+See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete license.
+--><link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
+<link rel="import" href="../../vaadin-element-mixin/vaadin-element-mixin.html">
+<link rel="import" href="../../vaadin-license-checker/vaadin-license-checker.html">
+<link rel="import" href="../../vaadin-button/src/vaadin-button.html">
+<link rel="import" href="../../vaadin-dialog/src/vaadin-dialog.html">
+<link rel="import" href="../../vaadin-checkbox/src/vaadin-checkbox.html">
+
+<dom-module id="vaadin-confirm-dialog">
+  <template>
+    <style>
+      :host {
+        display: none;
+      }
+    </style>
+    <vaadin-dialog id="dialog" opened="{{_dialogOpened}}" aria-label="[[_getAriaLabel(header)]]" no-close-on-outside-click="" no-close-on-esc="[[noCloseOnEsc]]">
+      <template>
+        <div part="header">
+          <slot name="header">
+            <h3 class="header">[[header]]</h3>
+          </slot>
+        </div>
+
+        <div part="message" id="message">
+          <slot></slot>
+          [[message]]
+        </div>
+
+        <div part="footer">
+          <div class="cancel-button">
+            <slot name="cancel-button">
+              <vaadin-button id="cancel" theme$="[[cancelTheme]]" on-click="_cancel" hidden$="[[!cancel]]" aria-describedby="message">
+                [[cancelText]]
+              </vaadin-button>
+            </slot>
+          </div>
+          <div class="remember-checkbox">
+            <slot name="remember-checkbox">
+              <vaadin-checkbox id="remember" checked="{{remember}}" theme$="[[rememberTheme]]" hidden$="[[!rememberId]]" aria-describedby="message">
+                [[_rememberTextComputed]]
+              </vaadin-checkbox>
+            </slot>
+          </div>
+          <div class="reject-button">
+            <slot name="reject-button">
+              <vaadin-button id="reject" theme$="[[rejectTheme]]" on-click="_reject" hidden$="[[!reject]]" aria-describedby="message">
+                [[rejectText]]
+              </vaadin-button>
+            </slot>
+          </div>
+          <div class="confirm-button">
+            <slot name="confirm-button">
+              <vaadin-button id="confirm" theme$="[[confirmTheme]]" on-click="_confirm" aria-describedby="message">
+                [[confirmText]]
+              </vaadin-button>
+            </slot>
+          </div>
+        </div>
+      </template>
+    </vaadin-dialog>
+  </template>
+
+  <script>(function () {
+  /**
+   * `<vaadin-confirm-dialog>` is a Web Component for showing alerts and asking for user confirmation.
+   *
+   * ```
+   * <vaadin-confirm-dialog on-confirm="_doConfirm">
+   *  Sample confirmation question
+   * </vaadin-confirm-dialog>
+   * ```
+   *
+   * ### Styling
+   *
+   * The following Shadow DOM parts are available for styling the dialog parts:
+   *
+   * Part name  | Description
+   * -----------|---------------------------------------------------------|
+   * `header`   | Header of the confirmation dialog
+   * `message`  | Container for the message of the dialog
+   * `footer`   | Container for the buttons
+   *
+   * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
+   *
+   * ### Custom content
+   *
+   * The following parts are available for replacement:
+   *
+   * Slot name         | Description
+   * ------------------|---------------------------------------------------------|
+   * `header`          | Header of the confirmation dialog
+   * `message`         | Container for the message of the dialog
+   * `cancel-button`   | Container for the Cancel button
+   * `reject-button`   | Container for the Reject button
+   * `confirm-button`  | Container for the Confirm button
+   *
+   * See examples of setting custom buttons into slots in the live demos.
+   *
+   * @memberof Vaadin
+   * @mixes Vaadin.ElementMixin
+   * @mixes Vaadin.ThemableMixin
+   * @demo demo/index.html
+   */
+  class ConfirmDialogElement extends Vaadin.ElementMixin(Vaadin.ThemableMixin(Polymer.Element)) {
+    static get is() {
+      return 'vaadin-confirm-dialog';
+    }
+
+    static get version() {
+      return '1.1.0';
+    }
+
+    static get properties() {
+      return {
+        /**
+         * True if the overlay is currently displayed.
+         */
+        opened: {
+          type: Boolean,
+          value: false,
+          notify: true,
+          observer: '_openedChanged'
+        },
+
+        /**
+         * Set the confirmation dialog title.
+         */
+        header: {
+          type: String,
+          value: ''
+        },
+
+        /**
+         * Set the message or confirmation question.
+         */
+        message: {
+          type: String
+        },
+
+        /**
+         * Text displayed on confirm-button.
+         */
+        confirmText: {
+          type: String,
+          value: 'Confirm'
+        },
+
+        /**
+         * Theme for a confirm-button.
+         */
+        confirmTheme: {
+          type: String,
+          value: 'primary'
+        },
+
+        /**
+         * Set to true to disable closing dialog on Escape press
+         */
+        noCloseOnEsc: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * Whether to show cancel button or not.
+         */
+        reject: {
+          type: Boolean,
+          reflectToAttribute: true,
+          value: false,
+          notify: true
+        },
+
+        /**
+         * Text displayed on reject-button.
+         */
+        rejectText: {
+          type: String,
+          value: 'Reject'
+        },
+
+        /**
+         * Theme for a reject-button.
+         */
+        rejectTheme: {
+          type: String,
+          value: 'error tertiary'
+        },
+
+        /**
+         * Whether to show cancel button or not.
+         */
+        cancel: {
+          type: Boolean,
+          reflectToAttribute: true,
+          value: false,
+          notify: true
+        },
+
+        /**
+         * Text displayed on cancel-button.
+         */
+        cancelText: {
+          type: String,
+          value: 'Cancel'
+        },
+
+        /**
+         * Theme for a cancel-button.
+         */
+        cancelTheme: {
+          type: String,
+          value: 'tertiary'
+        },
+        _confirmButton: {
+          type: Element
+        },
+        remember: {
+          type: Boolean,
+          value: false
+        },
+        rememberId: {
+          type: String
+        },
+        rememberText: {
+          type: String
+        },
+        _rememberTextComputed: {
+          type: String,
+          computed: '_computeRememberText()'
+        },
+        _dialogOpened: {
+          type: Boolean,
+          value: false
+        }
+      };
+    }
+
+    _computeRememberText() {
+      return this.rememberText || (this.reject ? 'Remember my choice' : 'Don\'t ask again');
+    }
+
+    _remember(choice) {
+      if (this.remember && this.rememberId) {
+        document.cookie = this.rememberId + "=" + choice + ";path=/";
+      }
+    }
+
+    _recall() {
+      if (this.rememberId) {
+        var choice = this._getCookie(this.rememberId);
+
+        if (choice) {
+          this[choice].apply(this);
+          return true;
+        }
+      }
+
+      return false;
+    }
+
+    _getCookie(cname) {
+      var name = cname + "=";
+      var decodedCookie = decodeURIComponent(document.cookie);
+      var ca = decodedCookie.split(';');
+
+      for (var i = 0; i < ca.length; i++) {
+        var c = ca[i];
+
+        while (c.charAt(0) == ' ') {
+          c = c.substring(1);
+        }
+
+        if (c.indexOf(name) == 0) {
+          return c.substring(name.length, c.length);
+        }
+      }
+
+      return null;
+    }
+
+    forget() {
+      if (this.rememberId) {
+        document.cookie = this.rememberId + "=;path=/;Max-Age=-99999999;";
+      }
+    }
+
+    ready() {
+      super.ready();
+      this.$.dialog.$.overlay.addEventListener('vaadin-overlay-escape-press', this._escPressed.bind(this));
+    }
+
+    _openedChanged() {
+      if (!this.opened || this._recall()) {
+        this._dialogOpened = false;
+        return;
+      }
+
+      this._dialogOpened = true;
+      Array.from(this.childNodes).forEach(c => {
+        var newChild = this.$.dialog.$.overlay.$.content.appendChild(c);
+
+        if (newChild.getAttribute && newChild.getAttribute('slot') == 'confirm-button' && newChild.focus) {
+          this._confirmButton = newChild;
+        }
+      });
+      Polymer.RenderStatus.beforeNextRender(this, () => {
+        var confirmButton = this._confirmButton || this.$.dialog.$.overlay.content.querySelector('#confirm');
+        confirmButton.focus();
+      });
+    }
+
+    _escPressed(event) {
+      if (!event.defaultPrevented) {
+        this._cancel();
+      }
+    }
+    /**
+     * @event confirm
+     * fired when Confirm button was pressed.
+     */
+
+
+    _confirm() {
+      this._remember('_confirm');
+
+      this.dispatchEvent(new CustomEvent('confirm'));
+      this.opened = false;
+    }
+    /**
+     * @event cancel
+     * fired when Cancel button or Escape key was pressed.
+     */
+
+
+    _cancel() {
+      this.dispatchEvent(new CustomEvent('cancel'));
+      this.opened = false;
+    }
+    /**
+     * @event reject
+     * fired when Reject button was pressed.
+     */
+
+
+    _reject() {
+      this._remember('_reject');
+
+      this.dispatchEvent(new CustomEvent('reject'));
+      this.opened = false;
+    }
+
+    _getAriaLabel(header) {
+      return header || 'confirmation';
+    }
+
+  }
+
+  customElements.define(ConfirmDialogElement.is, ConfirmDialogElement);
+  /**
+   * @namespace Vaadin
+   */
+
+  window.Vaadin.ConfirmDialogElement = ConfirmDialogElement;
+  const licenseChecker = window.Vaadin.developmentModeCallback && window.Vaadin.developmentModeCallback['vaadin-license-checker'];
+
+  if (typeof licenseChecker === 'function') {
+    licenseChecker(ConfirmDialogElement);
+  }
+})();</script>
+</dom-module>

--- a/demo/confirm-dialog-remember-demos.html
+++ b/demo/confirm-dialog-remember-demos.html
@@ -1,0 +1,145 @@
+<dom-module id="confirm-dialog-remember-demos">
+  <template>
+    <style include="vaadin-component-demo-shared-styles">
+      :host {
+        display: block;
+      }
+    </style>
+
+    <h3>Don't ask again</h3>
+    <p>
+      If you give the dialog a <code>remember-id</code>, the user will be offered an option to not
+      be shown this particular dialog again. No other code changes are needed; the dialog will trigger 
+      the appropriate event.
+    </p>
+    <vaadin-demo-snippet id="confirm-dialog-remember-demos-exit-dialog">
+      <template preserve-content>
+        <vaadin-confirm-dialog remember-id="close-editor" header="Close editor?">
+          Do you really want to close the editor?
+        </vaadin-confirm-dialog>
+
+        <vaadin-button id="open">Ask user</vaadin-button>
+        <vaadin-button id="forget">Forget answer</vaadin-button>
+        <span id="status"></span>
+        <script>
+          window.addDemoReadyListener('#confirm-dialog-remember-demos-exit-dialog', function(document) {
+            var dialog = document.querySelector('vaadin-confirm-dialog');
+            var button = document.querySelector('#open');
+            var forget = document.querySelector('#forget');
+            var status = document.querySelector('#status');
+            var count = 1;
+            button.addEventListener('click', function() {
+              status.innerText = '';
+              dialog.opened = true;
+            });
+            forget.addEventListener('click', function() {
+              dialog.forget();
+              status.innerText = count++ + '. Your answer is forgotten';
+            });
+            dialog.addEventListener('confirm', function() {
+              status.innerText = count++ + '. Confirmed';
+            });
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
+    <h3>Remember choice</h3>
+    <p>
+      Dialogs with multiple choices can automatically remember and apply the choice next time.
+    </p>
+    <vaadin-demo-snippet id="confirm-dialog-remember-demos-confirm-discard">
+      <template preserve-content>
+        <vaadin-confirm-dialog remember-id="unsaved-navigate" cancel reject header="Unsaved changes"
+            confirm-text="Save" reject-text="Discard">
+          Do you want to save or discard your changes before navigating away?
+        </vaadin-confirm-dialog>
+
+        <vaadin-button id="open">Ask user</vaadin-button>
+        <vaadin-button id="forget">Forget answer</vaadin-button>
+        <span id="status"></span>
+        <script>
+          window.addDemoReadyListener('#confirm-dialog-remember-demos-confirm-discard', function(document) {
+            var dialog = document.querySelector('vaadin-confirm-dialog');
+            var button = document.querySelector('#open');
+            var forget = document.querySelector('#forget');
+            var status = document.querySelector('#status');
+            var count = 1;
+            button.addEventListener('click', function() {
+              status.innerText = '';
+              dialog.opened = true;
+            });
+            forget.addEventListener('click', function() {
+              dialog.forget();
+              status.innerText = count++ + '. Your answer is forgotten';
+            });
+            dialog.addEventListener('confirm', function() {
+              status.innerText = count++ + '. Confirmed';
+            });
+            dialog.addEventListener('reject', function() {
+              status.innerText = count++ + '. Rejected';
+            });
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
+    <h3>Reset choices</h3>
+    <p>
+      The user might need to reset their choice. One way to do this is to provide an interface where the user can see 
+      and reset, all the remembered chices.
+    </p>
+    <vaadin-demo-snippet id="confirm-dialog-remember-demos-reset">
+      <template preserve-content>
+        <vaadin-confirm-dialog></vaadin-confirm-dialog>
+
+        <vaadin-button id="list">List remembered choices</vaadin-button>
+        <vaadin-button id="forget">Forget all</vaadin-button>
+        <pre><code id="status"></code></pre>
+        <script>
+          window.addDemoReadyListener('#confirm-dialog-remember-demos-reset', function(document) {
+            var dialog = document.querySelector('vaadin-confirm-dialog');
+            var list = document.querySelector('#list');
+            var forget = document.querySelector('#forget');
+            var status = document.querySelector('#status');
+
+            list.addEventListener('click', function() {
+              var res = '';
+              for ( var i = 0, len = localStorage.length; i < len; ++i ) {
+                var key =  localStorage.key(i);
+                if (key.startsWith(dialog._rememberIdPrefix)) {
+                  res += key.replace(dialog._rememberIdPrefix, '') + ' = ' + localStorage.getItem(key) + '\n';
+                }
+              }
+              status.innerText = res;
+            });
+
+            forget.addEventListener('click', function() {
+              var keys = [];
+              for ( var i = 0, len = localStorage.length; i < len; ++i ) {
+                var key =  localStorage.key(i);
+                if (key.startsWith(dialog._rememberIdPrefix)) {
+                  keys.push(key);
+                }
+              }
+              keys.forEach(key => {
+                localStorage.removeItem(key);
+              });
+              status.innerText = keys.length + ' choices forgotten.';
+            });
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+ 
+
+  </template>
+  <script>
+    class ConfirmDialogRememberDemos extends DemoReadyEventEmitter(ElementDemo(Polymer.Element)) {
+      static get is() {
+        return 'confirm-dialog-remember-demos';
+      }
+    }
+    customElements.define(ConfirmDialogRememberDemos.is, ConfirmDialogRememberDemos);
+  </script>
+</dom-module>

--- a/demo/confirm-dialog-remember-demos.html
+++ b/demo/confirm-dialog-remember-demos.html
@@ -87,7 +87,7 @@
     <h3>Remember choice when using custom buttons</h3>
     <p>
       If your dialog has custom (slotted) buttons, you can make use of the built-in remember- functionality if
-      by calling the dialog <code>_confirm()</code> and <code>_reject()</code> functions. 
+      by calling the dialog <code>doConfirm()</code> and <code>doReject()</code> functions. 
     </p>
     <vaadin-demo-snippet id="confirm-dialog-remember-demos-custom-buttons">
         <template preserve-content>
@@ -111,7 +111,7 @@
 
               var save = document.querySelector('#save');
               save.addEventListener('click', function() {
-                dialog._confirm();
+                dialog.doConfirm();
               });
 
               var count = 1;
@@ -137,46 +137,34 @@
 
     <h3>Reset choices</h3>
     <p>
-      The user might need to reset their choice. One way to do this is to provide an interface where the user can see 
-      and reset, all the remembered chices.
+      The user should be able to reset their remembered choice; you can remove individual keys 
+      by doing calling <code>forget()</code> on the dialog, or by calling 
+      <code>localStorage.removeItem()</code> directly.<br/>
+      You can also enumerate all the remembered choices and allow the user to reset each one.
+      A simple component for doing this is provided:
     </p>
     <vaadin-demo-snippet id="confirm-dialog-remember-demos-reset">
       <template preserve-content>
-        <vaadin-confirm-dialog></vaadin-confirm-dialog>
-
-        <vaadin-button id="list">List remembered choices</vaadin-button>
+        <vaadin-confirm-dialog-choice-list 
+          id="list"
+          descriptions='{"send": {"title": "Send email", "description":"Confirm sending email","reject":"Discard", "confirm":"Send"}}'>
+          <b>Nothing remembered</b>
+        </vaadin-confirm-dialog-choice-list>
+        <vaadin-button id="refresh">Refresh</vaadin-button>
         <vaadin-button id="forget">Forget all</vaadin-button>
-        <pre><code id="status"></code></pre>
         <script>
           window.addDemoReadyListener('#confirm-dialog-remember-demos-reset', function(document) {
             var dialog = document.querySelector('vaadin-confirm-dialog');
             var list = document.querySelector('#list');
+            var refresh = document.querySelector('#refresh');
             var forget = document.querySelector('#forget');
-            var status = document.querySelector('#status');
 
-            list.addEventListener('click', function() {
-              var res = '';
-              for ( var i = 0, len = localStorage.length; i < len; ++i ) {
-                var key =  localStorage.key(i);
-                if (key.startsWith(dialog._rememberIdPrefix)) {
-                  res += key.replace(dialog._rememberIdPrefix, '') + ' = ' + localStorage.getItem(key) + '\n';
-                }
-              }
-              status.innerText = res;
+            refresh.addEventListener('click', function() {
+              list.refresh();
             });
 
             forget.addEventListener('click', function() {
-              var keys = [];
-              for ( var i = 0, len = localStorage.length; i < len; ++i ) {
-                var key =  localStorage.key(i);
-                if (key.startsWith(dialog._rememberIdPrefix)) {
-                  keys.push(key);
-                }
-              }
-              keys.forEach(key => {
-                localStorage.removeItem(key);
-              });
-              status.innerText = keys.length + ' choices forgotten.';
+              list.forgetAll();
             });
           });
         </script>

--- a/demo/confirm-dialog-remember-demos.html
+++ b/demo/confirm-dialog-remember-demos.html
@@ -84,6 +84,57 @@
       </template>
     </vaadin-demo-snippet>
 
+    <h3>Remember choice when using custom buttons</h3>
+    <p>
+      If your dialog has custom (slotted) buttons, you can make use of the built-in remember- functionality if
+      by calling the dialog <code>_confirm()</code> and <code>_reject()</code> functions. 
+    </p>
+    <vaadin-demo-snippet id="confirm-dialog-remember-demos-custom-buttons">
+        <template preserve-content>
+          <vaadin-confirm-dialog remember-id="send" cancel reject header="Send message?"
+            reject-text="Discard">
+               <vaadin-button id="save" slot="confirm-button" theme="primary" aria-describedby="description">
+              <iron-icon icon="vaadin:envelope-open" slot="prefix"></iron-icon>
+              Send
+            </vaadin-button>
+          </vaadin-confirm-dialog>
+
+        <vaadin-button id="open">Ask user</vaadin-button>
+        <vaadin-button id="forget">Forget answer</vaadin-button>
+        <span id="status"></span>
+          <script>
+            window.addDemoReadyListener('#confirm-dialog-remember-demos-custom-buttons', function(document) {
+              var dialog = document.querySelector('vaadin-confirm-dialog');
+              var open = document.querySelector('#open');
+              var forget = document.querySelector('#forget');
+              var status = document.querySelector('#status');
+
+              var save = document.querySelector('#save');
+              save.addEventListener('click', function() {
+                dialog._confirm();
+              });
+
+              var count = 1;
+              open.addEventListener('click', function() {
+                status.innerText = '';
+                dialog.opened = true;
+              });
+              forget.addEventListener('click', function() {
+                dialog.forget();
+                status.innerText = count++ + '. Your answer is forgotten';
+              });
+
+              dialog.addEventListener('confirm', function() {
+                status.innerText = count++ + '. Confirmed';
+              });
+              dialog.addEventListener('reject', function() {
+                status.innerText = count++ + '. Rejected';
+              });
+            });
+          </script>
+        </template>
+      </vaadin-demo-snippet>
+
     <h3>Reset choices</h3>
     <p>
       The user might need to reset their choice. One way to do this is to provide an interface where the user can see 
@@ -132,7 +183,6 @@
       </template>
     </vaadin-demo-snippet>
  
-
   </template>
   <script>
     class ConfirmDialogRememberDemos extends DemoReadyEventEmitter(ElementDemo(Polymer.Element)) {

--- a/demo/demos.json
+++ b/demo/demos.json
@@ -10,6 +10,16 @@
         "description": "",
         "image": ""
       }
+    },
+    {
+      "name": "Remember choice",
+      "url": "confirm-dialog-remember-demos",
+      "src": "confirm-dialog-remember-demos.html",
+      "meta": {
+        "title": "vaadin-confirm-dialog Remember Choice Examples",
+        "description": "",
+        "image": ""
+      }
     }
   ]
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -14,6 +14,7 @@
   <script src="./confirm-dialog-demo.js"></script>
 
   <link rel="import" href="../vaadin-confirm-dialog.html">
+  <link rel="import" href="../vaadin-confirm-dialog-choice-list.html">
   <link rel="import" href="../../vaadin-button/vaadin-button.html">
   <link rel="import" href="../../vaadin-icons/vaadin-icons.html">
   <link rel="import" href="../../vaadin-lumo-styles/typography.html">

--- a/src/vaadin-confirm-dialog-choice-list.html
+++ b/src/vaadin-confirm-dialog-choice-list.html
@@ -23,9 +23,9 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           }
           *[hidden] { display: none; }
         </style>
-      <table hidden$="{{empty}}">
+      <table hidden$="{{_empty}}">
         <tbody>
-          <template is="dom-repeat" items="{{items}}">
+          <template is="dom-repeat" items="{{_items}}">
               <tr>
                   <td>{{item.title}}</td>
                   <td>{{item.description}}</td>
@@ -35,7 +35,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           </template>
         </tbody>
       </table>
-    <div hidden$="{{!empty}}"><slot>-</slot></div>
+    <div hidden$="{{!_empty}}"><slot>-</slot></div>
   </template>
 
 
@@ -75,26 +75,35 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               type: String,
               value: 'vaadin.vaadin-confirm-dialog.choice.'
             },
+            /**
+             * JSON allowing to specify texts for title, description, and the reject/confirm choices.
+             */
             descriptions: {
               type: Object,
               value: {},
               observer: 'refresh'
             }, 
-            items: {
-              type: Array,
-              value: []
-            },
-            empty: {
-              type: Boolean,
-              computed: '_isEmpty(items)'
-            },
+            /**
+             * Text for the button used to forget the remembered choice ("Reset").
+             */
             forgetButtonText: {
               type: String,
               value: 'Reset'
             },
+            /**
+             * Theme variant used for the "forget button" ("tertiary").
+             */
             forgetButtonTheme: {
               type: String,
               value: 'tertiary'
+            },
+            _items: {
+              type: Array,
+              value: []
+            },
+            _empty: {
+              type: Boolean,
+              computed: '_isEmpty(_items)'
             }
           };
         }
@@ -136,7 +145,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               choices.push(item);
             }
           }
-          this.items = choices;
+          this._items = choices;
         }
         forget(e) {
           localStorage.removeItem(this._rememberIdPrefix + e.model.item.rememberId);

--- a/src/vaadin-confirm-dialog-choice-list.html
+++ b/src/vaadin-confirm-dialog-choice-list.html
@@ -1,0 +1,174 @@
+<!--
+@license
+Copyright (c) 2018 Vaadin Ltd.
+This program is available under Commercial Vaadin Add-On License 3.0 (CVALv3).
+
+See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete license.
+-->
+
+<link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../../vaadin-button/src/vaadin-button.html">
+<link rel="import" href="../../vaadin-license-checker/vaadin-license-checker.html">
+
+<dom-module id="vaadin-confirm-dialog-choice-list">
+  <template>
+      <style>
+          :host {
+            display: block;
+          }
+          table {
+            width: 100%;
+            border-spacing: var(--lumo-space-s);
+            margin: calc(var(--lumo-space-s)  * -1);
+          }
+          *[hidden] { display: none; }
+        </style>
+      <table hidden$="{{empty}}">
+        <tbody>
+          <template is="dom-repeat" items="{{items}}">
+              <tr>
+                  <td>{{item.title}}</td>
+                  <td>{{item.description}}</td>
+                  <td>{{item.choice}}</td>
+                  <td><vaadin-button on-click="forget" theme$='{{forgetButtonTheme}}''>{{forgetButtonText}}</vaadin-button></td>
+              </tr>
+          </template>
+        </tbody>
+      </table>
+    <div hidden$="{{!empty}}"><slot>-</slot></div>
+  </template>
+
+
+  <script>
+    (function() {
+      /**
+       * `<vaadin-confirm-dialog-choice-list>` is a simple Web Component allowing the user to see and reset choices
+       * remembered by <vaadin-confirm-dialog>.
+       *
+       * ```
+       * <vaadin-confirm-dialog-choice-list 
+       *   descriptions='{"send": {"title": "Send email", "description":"Confirm sending email","reject":"Discard", "confirm":"Send"}}'>
+       *   <b>Nothing remembered</b>
+       * </vaadin-confirm-dialog-choice-list>
+       * ```
+       * The component takes a configuration JSON that can contain textual descriptions for each `remember-id` as follows:
+       * Key           | Description
+       * --------------|---------------------------------------------------------|
+       * `title `      | A short title, usually matching the dialog title
+       * `description` | Container for the message of the dialog
+       * `reject`      | Text for `reject` choice, should match dialog button
+       * `confirm`     | Text for `confirm` choice, should match dialog button
+       *
+       * @memberof Vaadin
+       * @demo demo/index.html
+       */
+      class ConfirmDialogChoiceListElement extends Polymer.Element {
+        static get is() {
+          return 'vaadin-confirm-dialog-choice-list';
+        }
+        static get version() {
+          return '1.1.0';
+        }
+        static get properties() {
+          return {
+            _rememberIdPrefix: {
+              type: String,
+              value: 'vaadin.vaadin-confirm-dialog.choice.'
+            },
+            descriptions: {
+              type: Object,
+              value: {},
+              observer: 'refresh'
+            }, 
+            items: {
+              type: Array,
+              value: []
+            },
+            empty: {
+              type: Boolean,
+              computed: '_isEmpty(items)'
+            },
+            forgetButtonText: {
+              type: String,
+              value: 'Reset'
+            },
+            forgetButtonTheme: {
+              type: String,
+              value: 'tertiary'
+            }
+          };
+        }
+        constructor() {
+          super();
+          window.addEventListener('storage', this._storage.bind(this));
+          this.refresh();
+        }
+        _isEmpty(array) {
+          return !array.length;
+        }
+        _storage(e) {
+            if (e.key.startsWith(this._rememberIdPrefix)) {
+              this.refresh();
+            }
+        }
+        refresh() {
+          var choices = [];
+          for ( var i = 0, len = localStorage.length; i < len; ++i ) {
+            var key =  localStorage.key(i);
+            if (key.startsWith(this._rememberIdPrefix)) {
+              var rememberId = key.replace(this._rememberIdPrefix, '');
+              var choice = localStorage.getItem(key);
+              var item = {
+                rememberId: rememberId,
+                title: rememberId,
+                choice: choice
+              }
+              if (this.descriptions && this.descriptions[rememberId]) {
+                var d = this.descriptions[rememberId];
+                if (d.title) {
+                  item.title = d.title;
+                }
+                if (!!d[choice.substr(1)]) {
+                  item.choice = d[choice.substr(1)];
+                }
+                item.description = d.description;
+              }
+              choices.push(item);
+            }
+          }
+          this.items = choices;
+        }
+        forget(e) {
+          localStorage.removeItem(this._rememberIdPrefix + e.model.item.rememberId);
+          this.refresh();
+        }
+        forgetAll() {
+          var keys = [];
+          for ( var i = 0, len = localStorage.length; i < len; ++i ) {
+            var key =  localStorage.key(i);
+            if (key.startsWith(this._rememberIdPrefix)) {
+              keys.push(key);
+            }
+          }
+          keys.forEach(key => {
+            localStorage.removeItem(key);
+          });
+          this.refresh();
+        }
+      }
+
+      customElements.define(ConfirmDialogChoiceListElement.is, ConfirmDialogChoiceListElement);
+
+      /**
+       * @namespace Vaadin
+       */
+      window.Vaadin.ConfirmDialogChoiceListElement = ConfirmDialogChoiceListElement;
+
+      const licenseChecker = window.Vaadin.developmentModeCallback
+        && window.Vaadin.developmentModeCallback['vaadin-license-checker'];
+      if (typeof licenseChecker === 'function') {
+        licenseChecker(ConfirmDialogChoiceListElement);
+      }
+    })();
+  </script>
+</dom-module>

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -20,6 +20,9 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       :host {
         display: none;
       }
+      [part="footer"] vaadin-checkbox[hidden] {
+        display: none !important;
+      }
     </style>
     <vaadin-dialog
       id="dialog"
@@ -49,7 +52,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           </div>
           <div class="remember-checkbox">
             <slot name="remember-checkbox">
-              <vaadin-checkbox id="remember" checked="{{remember}}" theme$="[[rememberTheme]]" hidden$="[[!rememberId]]" aria-describedby="message">
+              <vaadin-checkbox id="remember" checked="{{remember}}" theme$="[[rememberTheme]]" hidden$="[[!_showRemember]]" aria-describedby="message">
                 [[rememberText]]
               </vaadin-checkbox>
             </slot>
@@ -229,16 +232,23 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               type: String,
               value: 'vaadin.vaadin-confirm-dialog.choice.'
             },
+            _showRemember: {
+              type: Boolean,
+              computed: '_canRemember()'
+            },
             rememberText: {
               type: String,
               value: 'Don\'t ask me again'
             },
-
             _dialogOpened: {
               type: Boolean,
               value: false
             }
           };
+        }
+
+        _canRemember() {
+          return !!this.rememberId;
         }
 
         _remember(choice) {
@@ -250,6 +260,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         _recall() {
           if (this.rememberId) {
             var choice = localStorage.getItem(this._rememberIdPrefix + this.rememberId);
+            if (!choice) return false;
             switch (choice) {
               case '_confirm':
               case '_reject':

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -43,19 +43,19 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         </div>
 
         <div part="footer">
-          <div class="cancel-button">
-            <slot name="cancel-button">
-              <vaadin-button id="cancel" theme$="[[cancelTheme]]" on-click="_cancel" hidden$="[[!cancel]]" aria-describedby="message">
-                [[cancelText]]
-              </vaadin-button>
-            </slot>
-          </div>
           <div class="remember-checkbox">
             <slot name="remember-checkbox">
               <vaadin-checkbox id="remember" checked="{{remember}}" theme$="[[rememberTheme]]" hidden$="[[!_showRemember]]" aria-describedby="message">
                 [[rememberText]]
               </vaadin-checkbox>
             </slot>
+          </div>
+          <div class="cancel-button">
+              <slot name="cancel-button">
+                <vaadin-button id="cancel" theme$="[[cancelTheme]]" on-click="_cancel" hidden$="[[!cancel]]" aria-describedby="message">
+                  [[cancelText]]
+                </vaadin-button>
+              </slot>
           </div>
           <div class="reject-button">
             <slot name="reject-button">

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -20,9 +20,6 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       :host {
         display: none;
       }
-      [part="footer"] vaadin-checkbox[hidden] {
-        display: none !important;
-      }
     </style>
     <vaadin-dialog
       id="dialog"
@@ -52,21 +49,21 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
           </div>
           <div class="cancel-button">
               <slot name="cancel-button">
-                <vaadin-button id="cancel" theme$="[[cancelTheme]]" on-click="_cancel" hidden$="[[!cancel]]" aria-describedby="message">
+                <vaadin-button id="cancel" theme$="[[cancelTheme]]" on-click="doCancel" hidden$="[[!cancel]]" aria-describedby="message">
                   [[cancelText]]
                 </vaadin-button>
               </slot>
           </div>
           <div class="reject-button">
             <slot name="reject-button">
-              <vaadin-button id="reject" theme$="[[rejectTheme]]" on-click="_reject" hidden$="[[!reject]]" aria-describedby="message">
+              <vaadin-button id="reject" theme$="[[rejectTheme]]" on-click="doReject" hidden$="[[!reject]]" aria-describedby="message">
                 [[rejectText]]
               </vaadin-button>
             </slot>
           </div>
           <div class="confirm-button">
             <slot name="confirm-button">
-              <vaadin-button id="confirm" theme$="[[confirmTheme]]" on-click="_confirm" aria-describedby="message">
+              <vaadin-button id="confirm" theme$="[[confirmTheme]]" on-click="doConfirm" aria-describedby="message">
                 [[confirmText]]
               </vaadin-button>
             </slot>
@@ -193,7 +190,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
              */
             rejectTheme: {
               type: String,
-              value: 'error tertiary'
+              value: 'error primary'
             },
             /**
              * Whether to show cancel button or not.
@@ -221,10 +218,18 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             _confirmButton: {
               type: Element
             },
+            /**
+             * Whether or not the selected choice [confirm|reject] should be remembered and automatically applied next time.
+             */
             remember: {
               type: Boolean,
               value: false
             },
+            /**
+             * Enables the functionality that allows the user to choose wheter their choice [confirm|reject] should be
+             * remembered and automatically applied next time. A unique identifier for this particular dialog / question
+             * must be provided, so that only relevant choices are affected.
+             */
             rememberId: {
               type: String
             },
@@ -236,6 +241,9 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               type: Boolean,
               computed: '_canRemember()'
             },
+            /**
+             * Text displayed for the "remember choice" checkbox.
+             */
             rememberText: {
               type: String,
               value: 'Don\'t ask me again'
@@ -260,11 +268,11 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         _recall() {
           if (this.rememberId) {
             var choice = localStorage.getItem(this._rememberIdPrefix + this.rememberId);
-            if (!choice) return false;
+            if (!choice) return null;
             switch (choice) {
-              case '_confirm':
-              case '_reject':
-                this[choice].apply(this);
+              case 'Confirm':
+              case 'Reject':
+                this['do'+choice].apply(this);
                 return choice;
               default:
                 console.warn("Invalid choice " + choice + " for dialog " + this.rememberId);
@@ -307,7 +315,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 
         _escPressed(event) {
           if (!event.defaultPrevented) {
-            this._cancel();
+            this.doCancel();
           }
         }
 
@@ -315,8 +323,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
          * @event confirm
          * fired when Confirm button was pressed.
          */
-        _confirm() {
-          this._remember('_confirm');
+        doConfirm() {
+          this._remember('Confirm');
           this.dispatchEvent(new CustomEvent('confirm'));
           this.opened = false;
         }
@@ -325,7 +333,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
          * @event cancel
          * fired when Cancel button or Escape key was pressed.
          */
-        _cancel() {
+        doCancel() {
           this.dispatchEvent(new CustomEvent('cancel'));
           this.opened = false;
         }
@@ -334,8 +342,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
          * @event reject
          * fired when Reject button was pressed.
          */
-        _reject() {
-          this._remember('_reject');
+        doReject() {
+          this._remember('Reject');
           this.dispatchEvent(new CustomEvent('reject'));
           this.opened = false;
         }

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -265,12 +265,12 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               case '_confirm':
               case '_reject':
                 this[choice].apply(this);
-                return true;
+                return choice;
               default:
                 console.warn("Invalid choice " + choice + " for dialog " + this.rememberId);
             }
           }
-          return false;
+          return null;
         }
 
         forget() {
@@ -285,7 +285,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         }
 
         _openedChanged() {
-          if (!this.opened || this._recall()) {
+          if (!this.opened || !!this._recall()) {
             this._dialogOpened = false;
             return;
           }

--- a/src/vaadin-confirm-dialog.html
+++ b/src/vaadin-confirm-dialog.html
@@ -12,6 +12,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
 <link rel="import" href="../../vaadin-license-checker/vaadin-license-checker.html">
 <link rel="import" href="../../vaadin-button/src/vaadin-button.html">
 <link rel="import" href="../../vaadin-dialog/src/vaadin-dialog.html">
+<link rel="import" href="../../vaadin-checkbox/src/vaadin-checkbox.html">
 
 <dom-module id="vaadin-confirm-dialog">
   <template>
@@ -22,7 +23,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
     </style>
     <vaadin-dialog
       id="dialog"
-      opened="{{opened}}"
+      opened="{{_dialogOpened}}"
       aria-label="[[_getAriaLabel(header)]]"
       no-close-on-outside-click
       no-close-on-esc="[[noCloseOnEsc]]">
@@ -44,6 +45,13 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
               <vaadin-button id="cancel" theme$="[[cancelTheme]]" on-click="_cancel" hidden$="[[!cancel]]" aria-describedby="message">
                 [[cancelText]]
               </vaadin-button>
+            </slot>
+          </div>
+          <div class="remember-checkbox">
+            <slot name="remember-checkbox">
+              <vaadin-checkbox id="remember" checked="{{remember}}" theme$="[[rememberTheme]]" hidden$="[[!rememberId]]" aria-describedby="message">
+                [[rememberText]]
+              </vaadin-checkbox>
             </slot>
           </div>
           <div class="reject-button">
@@ -209,8 +217,55 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
             },
             _confirmButton: {
               type: Element
+            },
+            remember: {
+              type: Boolean,
+              value: false
+            },
+            rememberId: {
+              type: String
+            },
+            _rememberIdPrefix: {
+              type: String,
+              value: 'vaadin.vaadin-confirm-dialog.choice.'
+            },
+            rememberText: {
+              type: String,
+              value: 'Don\'t ask me again'
+            },
+
+            _dialogOpened: {
+              type: Boolean,
+              value: false
             }
           };
+        }
+
+        _remember(choice) {
+          if (this.remember && this.rememberId) {
+            localStorage.setItem(this._rememberIdPrefix + this.rememberId, choice)
+          }
+        }
+
+        _recall() {
+          if (this.rememberId) {
+            var choice = localStorage.getItem(this._rememberIdPrefix + this.rememberId);
+            switch (choice) {
+              case '_confirm':
+              case '_reject':
+                this[choice].apply(this);
+                return true;
+              default:
+                console.warn("Invalid choice " + choice + " for dialog " + this.rememberId);
+            }
+          }
+          return false;
+        }
+
+        forget() {
+          if (this.rememberId) {
+            localStorage.removeItem(this._rememberIdPrefix + this.rememberId);
+          }
         }
 
         ready() {
@@ -219,9 +274,12 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         }
 
         _openedChanged() {
-          if (!this.opened) {
+          if (!this.opened || this._recall()) {
+            this._dialogOpened = false;
             return;
           }
+
+          this._dialogOpened = true;
 
           Array.from(this.childNodes).forEach(c => {
             var newChild = this.$.dialog.$.overlay.$.content.appendChild(c);
@@ -247,6 +305,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
          * fired when Confirm button was pressed.
          */
         _confirm() {
+          this._remember('_confirm');
           this.dispatchEvent(new CustomEvent('confirm'));
           this.opened = false;
         }
@@ -265,6 +324,7 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
          * fired when Reject button was pressed.
          */
         _reject() {
+          this._remember('_reject');
           this.dispatchEvent(new CustomEvent('reject'));
           this.opened = false;
         }

--- a/test/remember-api-test.html
+++ b/test/remember-api-test.html
@@ -1,0 +1,57 @@
+<!doctype html>
+
+<head>
+  <meta charset="UTF-8">
+  <title>vaadin-confirm-dialog tests</title>
+  <script src="../../web-component-tester/browser.js"></script>
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../test-fixture/test-fixture.html">
+  <link rel="import" href="../vaadin-confirm-dialog.html">
+</head>
+
+<body>
+  <test-fixture id="default">
+    <template>
+      <vaadin-confirm-dialog remember-id="dialog-test">Confirmation message</vaadin-confirm-dialog>
+    </template>
+  </test-fixture>
+
+  <script>
+    describe('Remember choice test', function() {
+      var confirm, dialog, overlay, content;
+
+      beforeEach(function() {
+        confirm = fixture('default');
+        dialog = confirm.$.dialog;
+      });
+
+      it('should remember option', function() {
+        confirm.opened = true;
+        overlay = dialog.$.overlay;
+        content = overlay.content;
+        var rememberCheckbox = content.querySelector('#remember');
+        expect(rememberCheckbox.checked).to.be.false;
+        rememberCheckbox.checked = true;
+        confirm.doConfirm();
+        expect(dialog.opened).to.be.false;
+        expect(confirm._recall()).to.equal('Confirm');
+      });
+
+      it('should apply remembered option', function() {
+        confirm.opened = true;
+        expect(dialog.opened).to.be.false;
+        expect(confirm._recall()).to.equal('Confirm');
+      });
+
+      it('should forget option', function() {
+        confirm.opened = true;
+        expect(dialog.opened).to.be.false;
+        confirm.forget();
+        confirm.opened = true;
+        expect(dialog.opened).to.be.true;
+        expect(confirm._recall()).to.be.null;
+      });
+      
+    });
+  </script>
+</body>

--- a/test/test-suites.js
+++ b/test/test-suites.js
@@ -2,5 +2,6 @@ window.VaadinConfirmDialogSuites = [
   'alert-api-test.html',
   'cancel-api-test.html',
   'confirmation-api-test.html',
-  'confirm-reject-api-test.html'
+  'confirm-reject-api-test.html',
+  'remember-api-test.html'
 ];

--- a/theme/lumo/vaadin-confirm-dialog-styles.html
+++ b/theme/lumo/vaadin-confirm-dialog-styles.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../../../vaadin-lumo-styles/spacing.html">
 <link rel="import" href="../../../vaadin-dialog/theme/lumo/vaadin-dialog.html">
 <link rel="import" href="../../../vaadin-button/theme/lumo/vaadin-button.html">
+<link rel="import" href="../../../vaadin-checkbox/theme/lumo/vaadin-checkbox.html">
 
 <dom-module id="lumo-confirm-dialog" theme-for="vaadin-confirm-dialog">
   <template>
@@ -39,8 +40,12 @@
       }
 
       .cancel-button {
-        flex-grow: 1;
         margin-left: calc(var(--lumo-space-s) * -1);
+      }
+
+      .remember-checkbox {
+        flex-grow: 1;
+        align-self: center;
       }
 
       .confirm-button {

--- a/theme/lumo/vaadin-confirm-dialog-styles.html
+++ b/theme/lumo/vaadin-confirm-dialog-styles.html
@@ -43,6 +43,7 @@
         flex-grow: 1;
         align-self: center;
         margin-left: calc(var(--lumo-space-s) * -1);
+        color: var(--lumo-secondary-text-color);
       }
 
       .cancel-button {
@@ -58,7 +59,7 @@
         margin-left: var(--lumo-space-s);
       }
 
-      @media (max-width: 360px) {
+      @media (max-width: 600px) {
         [part="footer"] {
           flex-direction: column-reverse;
         }
@@ -79,6 +80,10 @@
         }
 
         [part="footer"] .cancel-button {
+          margin-bottom: var(--lumo-space-s);
+        }
+
+        [part="footer"] .remember-checkbox {
           margin-bottom: var(--lumo-space-s);
         }
       }

--- a/theme/lumo/vaadin-confirm-dialog-styles.html
+++ b/theme/lumo/vaadin-confirm-dialog-styles.html
@@ -39,13 +39,14 @@
         padding-right: var(--lumo-space-s);
       }
 
-      .cancel-button {
-        margin-left: calc(var(--lumo-space-s) * -1);
-      }
-
       .remember-checkbox {
         flex-grow: 1;
         align-self: center;
+        margin-left: calc(var(--lumo-space-s) * -1);
+      }
+
+      .cancel-button {
+        margin-right: calc(var(--lumo-space-s) * -1);
       }
 
       .confirm-button {

--- a/theme/material/vaadin-confirm-dialog-styles.html
+++ b/theme/material/vaadin-confirm-dialog-styles.html
@@ -20,7 +20,12 @@
         margin-right: 8px;
       }
 
-      @media (max-width: 360px) {
+     .remember-checkbox {
+        flex-grow: 1;
+        align-self: center;
+      }
+
+      @media (max-width: 600px) {
         [part="footer"] {
           flex-direction: column-reverse;
           align-items: flex-end;

--- a/theme/material/vaadin-confirm-dialog.html
+++ b/theme/material/vaadin-confirm-dialog.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../../../vaadin-dialog/theme/material/vaadin-dialog.html">
 <link rel="import" href="../../../vaadin-dialog/src/vaadin-dialog.html">
 <link rel="import" href="../../../vaadin-button/theme/material/vaadin-button.html">
+<link rel="import" href="../../../vaadin-checkbox/theme/material/vaadin-checkbox.html">
 <link rel="import" href="../../../vaadin-overlay/theme/material/vaadin-overlay.html">
 <link rel="import" href="vaadin-confirm-dialog-styles.html">
 <link rel="import" href="../../src/vaadin-confirm-dialog.html">

--- a/vaadin-confirm-dialog-choice-list.html
+++ b/vaadin-confirm-dialog-choice-list.html
@@ -1,0 +1,1 @@
+<link rel="import" href="src/vaadin-confirm-dialog-choice-list.html">


### PR DESCRIPTION
Demo: https://emarc.github.io/vaadin-confirm-dialog/components/vaadin-confirm-dialog/demo/#confirm-dialog-remember-demos
(please reload _hard_ or use incognito)

### `<vaadin-confirm-dialog>`

- Providing a rememberId will show a "[ ] Don't ask me again" checkbox (customizable text)
- If checked, the choice [confirm|reject] is stored in localStorage and automatically applied the next time the dialog would have opened; for the programmer, it's seamless.
- `forget()` will cause the remembered choice to be forgotten
- `_cancel()`, `_confirm()` and `_reject()` are now `doCancel()`, `doConfirm()` and `doReject()`; these are supposed to be called e.g when using slotted buttons, so that all the internal logic still gets triggered. The naming is up for debate, BUT the un-prefixed `cancel` (etc) is a used to enable the cancel button and so on...

**Theme**

- All buttons and now right aligned, "Don't remember" is to the left. This is according to Jounis design (he wanted the buttons moved anyway)
- Reject button primary instead of tertiary (again according to Jounis design)
- The breakpoint for narrow screen has been changed from 360px to 600px in cooperation with Jouni

### `<vaadin-confirm-dialog-choice-list>`

This is a simple UI that lists all the remembered choices in localStorage, so they can be forgotten.
The user must be able to reset the choices somehow, so it needs to be as easy as possible for the devs to make it so.
However:

- The name of the component is sh*t
- I would have liked to let the user provide a template, then dom-if over that; but I could not find a good example how to do that, apparently it is non-trivial - let me know if it is. With lit around the corner I decided not to try. For now the component renders in lightDOM and has no theme. 

**Tests**
Does not test that events are fired; I've seen other components use Sinon, but confirm-dialog does not seem to have any tests for events, so I opted to not figure out whether or not to add Sinon.